### PR TITLE
Update pruning frequency docs

### DIFF
--- a/docs/management/limiting-caches.md
+++ b/docs/management/limiting-caches.md
@@ -72,7 +72,7 @@ Cachex.start(:my_cache,
 )
 ```
 
-This will spawn a cache hook to continually prune your cache periodically, based on the options you provided. You can pass options for `Cachex.prune/3` as the second element of the `args` tuple, and customize the hook itself in the third element. Currently the only supported parameter for the hook is `:frequency`, which defaults to `1000` (one second). Please see the documentation for an updated list of supported configuration.
+This will spawn a cache hook to continually prune your cache periodically, based on the options you provided. You can pass options for `Cachex.prune/3` as the second element of the `args` tuple, and customize the hook itself in the third element. Currently the only supported parameter for the hook is `:frequency`, which defaults to `3000` (three seconds). Please see the documentation for an updated list of supported configuration.
 
 If you need more exact timing you can opt to use `Cachex.Limit.Evented` rather than `Cachex.Limit.Scheduled`, which will react to hook events inside a cache instead of running on a schedule:
 

--- a/lib/cachex/limit/scheduled.ex
+++ b/lib/cachex/limit/scheduled.ex
@@ -21,8 +21,8 @@ defmodule Cachex.Limit.Scheduled do
     * `:frequency`
 
       The polling frequency for this hook to use when scheduling cache pruning.
-      This should be an non-negative number of milliseconds. Defaults to `1000`,
-      which is once per second.
+      This should be a non-negative number of milliseconds. Defaults to `3000`,
+      which is three seconds.
 
   """
   use Cachex.Hook


### PR DESCRIPTION
## Summary
- update module docs for Cachex.Limit.Scheduled to show default 3-second interval
- fix limiting caches documentation to match the default frequency

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a493d8f08331a74894c1bc36f4c5